### PR TITLE
Update http.py

### DIFF
--- a/lib/common/http.py
+++ b/lib/common/http.py
@@ -10,7 +10,8 @@ These are the first places URI requests are processed.
 
 """
 
-from BaseHTTPServer import BaseHTTPRequestHandler
+from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+from SocketServer import ThreadingMixIn
 import BaseHTTPServer, threading, ssl, os, string, random
 from pydispatch import dispatcher
 import re
@@ -63,6 +64,9 @@ def checksum8(s):
 # HTTP servers and handlers.
 #
 ###############################################################
+
+class EmpireHTTPServer(ThreadingMixIn, HTTPServer):
+    pass
 
 class RequestHandler(BaseHTTPRequestHandler):
     """
@@ -161,7 +165,7 @@ class EmpireServer(threading.Thread):
             threading.Thread.__init__(self)
             self.server = None
 
-            self.server = BaseHTTPServer.HTTPServer((lhost, int(port)), RequestHandler)
+            self.server = EmpireHTTPServer((lhost, int(port)), RequestHandler)
             
             # pass the agent handler object along for the RequestHandler
             self.server.agents = handler


### PR DESCRIPTION
HTTPServer is synchronous and results in denial of service with half-open connections (e.g. originating from port scanners). Quick resolution is to use the ThreadingMixin as described in https://docs.python.org/2/library/socketserver.html
This will not completely prevent DoS conditions, however it will spawn multiple threads in order to service multiple clients in parallel.
